### PR TITLE
EFRepository bugfix

### DIFF
--- a/BLM.EF6.Tests/EntityFrameworkBasicTests.cs
+++ b/BLM.EF6.Tests/EntityFrameworkBasicTests.cs
@@ -128,7 +128,7 @@ namespace BLM.EF6.Tests
             var reloadedValid = _repo.Entities(_identity).FirstOrDefault(a => a.Id == valid.Id);
             Assert.AreEqual(reloadedValid.Guid, newGuid);
         }
-
+        
         [TestMethod]
         [ExpectedException(typeof(AuthorizationFailedException))]
         public async Task ModifyFailedAsync()

--- a/BLM.EF6/EfRepository.cs
+++ b/BLM.EF6/EfRepository.cs
@@ -221,13 +221,13 @@ namespace BLM.EF6
                 }
             }
 
-            var added = entries.Where(a => a.State == EntityState.Added).ToList();
-            var modified = entries.Where(a => a.State == EntityState.Modified).ToList();
+            var added = entries.Where(a => a.State == EntityState.Added).Select(a => new { CurrentValues = a.CurrentValues.Clone() }).ToList();
+            var modified = entries.Where(a => a.State == EntityState.Modified).Select(a => new { OriginalValues = a.OriginalValues.Clone(), CurrentValues = a.CurrentValues.Clone() }).ToList();
             var removed = entries.Where(a => a.State == EntityState.Deleted).Select(a => CreateWithValues(a.OriginalValues)).ToList();
 
             _dbcontext.SaveChanges();
 
-            added.ForEach(async a => await Listen.CreatedAsync(CreateWithValues(a.OriginalValues), contextInfo));
+            added.ForEach(async a => await Listen.CreatedAsync(CreateWithValues(a.CurrentValues), contextInfo));
             modified.ForEach(async a => await Listen.ModifiedAsync(CreateWithValues(a.OriginalValues), CreateWithValues(a.CurrentValues), contextInfo));
             removed.ForEach(async a => await Listen.RemovedAsync(a, contextInfo));
         }

--- a/BLM.Tests/ListenerTests.cs
+++ b/BLM.Tests/ListenerTests.cs
@@ -257,7 +257,7 @@ namespace BLM.Tests
 
             var time = DateTime.Now.Subtract(start).TotalMilliseconds;
 
-            Assert.IsTrue(time < 500);
+            Assert.IsTrue(time < 1000);
 
             Assert.IsFalse(MockListener.WasOnCreatedCalled);
             Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);

--- a/BLM.Tests/ListenerTests.cs
+++ b/BLM.Tests/ListenerTests.cs
@@ -20,6 +20,7 @@ namespace BLM.Tests
         public static bool WasOnCreatedCalled;
         public static bool WasOnCreationValidationFailedCalled;
         public static bool WasOnModifiedCalled;
+        public static bool? EntitesWereNotTheSameOnCalling;
         public static bool WasOnModificationFailedCalled;
         public static bool WasOnDeletedCalled;
         public static bool WasOnDeletionFailedCalled;
@@ -36,10 +37,34 @@ namespace BLM.Tests
 
         public async Task OnModifiedAsync(T original, T modified, IContextInfo user)
         {
+            if (original != null)
+            {
+                EntitesWereNotTheSameOnCalling = !original.Equals(modified);
+            }
+            else if (modified != null)
+            {
+                EntitesWereNotTheSameOnCalling = true;
+            }
+            else
+            {
+                EntitesWereNotTheSameOnCalling = false;
+            }
             WasOnModifiedCalled = true;
         }
         public async Task OnModificationFailedAsync(T original, T modified, IContextInfo user)
         {
+            if (original != null)
+            {
+                EntitesWereNotTheSameOnCalling = !original.Equals(modified);
+            }
+            else if (modified != null)
+            {
+                EntitesWereNotTheSameOnCalling = !modified.Equals(original);
+            }
+            else
+            {
+                EntitesWereNotTheSameOnCalling = false;
+            }
             WasOnModificationFailedCalled = true;
         }
 
@@ -63,6 +88,8 @@ namespace BLM.Tests
             WasOnModificationFailedCalled = false;
             WasOnDeletedCalled = false;
             WasOnDeletionFailedCalled = false;
+
+            EntitesWereNotTheSameOnCalling = null;
         }
     }
     #endregion
@@ -79,6 +106,10 @@ namespace BLM.Tests
     {
 
         MockEntity ent = new MockEntity();
+        MockEntity ent2 = new MockEntity()
+        {
+            Guid = Guid.NewGuid().ToString()
+        };
         GenericContextInfo ctx = new GenericContextInfo(Thread.CurrentPrincipal.Identity);
 
         [TestMethod]
@@ -115,7 +146,7 @@ namespace BLM.Tests
             MockListener.Reset();
             ObjectListener.Reset();
 
-            await Listen.ModifiedAsync(ent, ent, ctx);
+            await Listen.ModifiedAsync(ent, ent2, ctx);
 
             Assert.IsFalse(MockListener.WasOnCreatedCalled);
             Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);
@@ -123,39 +154,21 @@ namespace BLM.Tests
             Assert.IsFalse(MockListener.WasOnModificationFailedCalled);
             Assert.IsFalse(MockListener.WasOnDeletedCalled);
             Assert.IsFalse(MockListener.WasOnDeletionFailedCalled);
+
+            Assert.IsTrue(MockListener.EntitesWereNotTheSameOnCalling.HasValue && MockListener.EntitesWereNotTheSameOnCalling.Value);
         }
 
+        /// <summary>
+        /// Test the 3 different modify listeners, all of them need to run, and we pass two different entities into them
+        /// </summary>
         [TestMethod]
         public async Task MultipleModifiedListeners()
         {
             MockListener.Reset();
             MockListener2.Reset();
-
-            await Listen.ModifiedAsync(ent, ent, ctx);
-
-            Assert.IsFalse(MockListener.WasOnCreatedCalled);
-            Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);
-            Assert.IsTrue(MockListener.WasOnModifiedCalled);
-            Assert.IsFalse(MockListener.WasOnModificationFailedCalled);
-            Assert.IsFalse(MockListener.WasOnDeletedCalled);
-            Assert.IsFalse(MockListener.WasOnDeletionFailedCalled);
-
-            Assert.IsFalse(MockListener2.WasOnCreatedCalled);
-            Assert.IsFalse(MockListener2.WasOnCreationValidationFailedCalled);
-            Assert.IsTrue(MockListener2.WasOnModifiedCalled);
-            Assert.IsFalse(MockListener2.WasOnModificationFailedCalled);
-            Assert.IsFalse(MockListener2.WasOnDeletedCalled);
-            Assert.IsFalse(MockListener2.WasOnDeletionFailedCalled);
-        }
-
-        [TestMethod]
-        public async Task MultipleModifiedListeners_Inheritance()
-        {
-            MockListener.Reset();
-            MockListener2.Reset();
             ObjectListener.Reset();
 
-            await Listen.ModifiedAsync(ent, ent, ctx);
+            await Listen.ModifiedAsync(ent, ent2, ctx);
 
             Assert.IsFalse(MockListener.WasOnCreatedCalled);
             Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);
@@ -170,7 +183,6 @@ namespace BLM.Tests
             Assert.IsFalse(MockListener2.WasOnModificationFailedCalled);
             Assert.IsFalse(MockListener2.WasOnDeletedCalled);
             Assert.IsFalse(MockListener2.WasOnDeletionFailedCalled);
-
 
             Assert.IsFalse(ObjectListener.WasOnCreatedCalled);
             Assert.IsFalse(ObjectListener.WasOnCreationValidationFailedCalled);
@@ -178,8 +190,53 @@ namespace BLM.Tests
             Assert.IsFalse(ObjectListener.WasOnModificationFailedCalled);
             Assert.IsFalse(ObjectListener.WasOnDeletedCalled);
             Assert.IsFalse(ObjectListener.WasOnDeletionFailedCalled);
+
+            Assert.IsTrue(MockListener.EntitesWereNotTheSameOnCalling.HasValue && MockListener.EntitesWereNotTheSameOnCalling.Value);
+            Assert.IsTrue(MockListener2.EntitesWereNotTheSameOnCalling.HasValue && MockListener2.EntitesWereNotTheSameOnCalling.Value);
+            Assert.IsTrue(ObjectListener.EntitesWereNotTheSameOnCalling.HasValue && ObjectListener.EntitesWereNotTheSameOnCalling.Value);
         }
 
+        /// <summary>
+        /// Only the object modify listener should run, because we pass two (different) objects into the listener
+        /// </summary>
+        [TestMethod]
+        public async Task MultipleModifiedListeners_TestInheritance()
+        {
+            MockListener.Reset();
+            MockListener2.Reset();
+            ObjectListener.Reset();
+
+            await Listen.ModifiedAsync(new object(), new { sajt = true }, ctx);
+
+            Assert.IsFalse(MockListener.WasOnCreatedCalled);
+            Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);
+            Assert.IsFalse(MockListener.WasOnModifiedCalled);
+            Assert.IsFalse(MockListener.WasOnModificationFailedCalled);
+            Assert.IsFalse(MockListener.WasOnDeletedCalled);
+            Assert.IsFalse(MockListener.WasOnDeletionFailedCalled);
+
+            Assert.IsFalse(MockListener2.WasOnCreatedCalled);
+            Assert.IsFalse(MockListener2.WasOnCreationValidationFailedCalled);
+            Assert.IsFalse(MockListener2.WasOnModifiedCalled);
+            Assert.IsFalse(MockListener2.WasOnModificationFailedCalled);
+            Assert.IsFalse(MockListener2.WasOnDeletedCalled);
+            Assert.IsFalse(MockListener2.WasOnDeletionFailedCalled);
+
+            Assert.IsFalse(ObjectListener.WasOnCreatedCalled);
+            Assert.IsFalse(ObjectListener.WasOnCreationValidationFailedCalled);
+            Assert.IsTrue(ObjectListener.WasOnModifiedCalled);
+            Assert.IsFalse(ObjectListener.WasOnModificationFailedCalled);
+            Assert.IsFalse(ObjectListener.WasOnDeletedCalled);
+            Assert.IsFalse(ObjectListener.WasOnDeletionFailedCalled);
+
+            Assert.IsNull(MockListener.EntitesWereNotTheSameOnCalling);
+            Assert.IsNull(MockListener2.EntitesWereNotTheSameOnCalling);
+            Assert.IsTrue(ObjectListener.EntitesWereNotTheSameOnCalling.HasValue && ObjectListener.EntitesWereNotTheSameOnCalling.Value);
+        }
+
+        /// <summary>
+        /// A little loadtest like something for check the performance is OK
+        /// </summary>
         [TestMethod]
         public async Task LoadTest()
         {
@@ -191,7 +248,7 @@ namespace BLM.Tests
 
             List<Task> tasks = new List<Task>();
 
-            for (int i = 0; i < 5000000; i++)
+            for (int i = 0; i < 500000; i++)
             {
                 tasks.Add(Listen.ModifiedAsync(ent, ent, ctx));
             }
@@ -200,7 +257,7 @@ namespace BLM.Tests
 
             var time = DateTime.Now.Subtract(start).TotalMilliseconds;
 
-            Assert.IsTrue(time < 10000);
+            Assert.IsTrue(time < 500);
 
             Assert.IsFalse(MockListener.WasOnCreatedCalled);
             Assert.IsFalse(MockListener.WasOnCreationValidationFailedCalled);

--- a/BLM.sln
+++ b/BLM.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.25914.0
+VisualStudioVersion = 15.0.25920.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BLM", "BLM\BLM.csproj", "{D5F2CC21-9001-4CB4-A7D6-56D826F6DC24}"
 EndProject
@@ -13,6 +13,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BLM.Tests", "BLM.Tests\BLM.
 	EndProjectSection
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BLM.EF6.Tests", "BLM.EF6.Tests\BLM.EF6.Tests.csproj", "{CB08C81E-21F4-41C9-89F3-A8C0226E8F94}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tests", "Tests", "{FE6447C3-33CF-4486-8835-68B9F107F9DE}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -39,5 +41,9 @@ Global
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{D0A0CB4A-F053-470F-8D49-43CAA81B3EAB} = {FE6447C3-33CF-4486-8835-68B9F107F9DE}
+		{CB08C81E-21F4-41C9-89F3-A8C0226E8F94} = {FE6447C3-33CF-4486-8835-68B9F107F9DE}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
- Modify listener fixed
- New test cases for testing the given parameters in different listeners
- Generic inheritance testing: now we test if we pass objects, the mock listeners should not run. If we pass two mock entities, all of the listeners should run.