### PR TITLE
EFRepository should update added values for get the newly created entity's primary key

### DIFF
--- a/BLM.EF6/EfRepository.cs
+++ b/BLM.EF6/EfRepository.cs
@@ -274,13 +274,13 @@ namespace BLM.EF6
             }
 
             // Added should be updated after saving changes for get the ID of the newly created entity
-            var added = entries.Where(a => a.State == EntityState.Added).ToList();
+            var added = entries.Where(a => a.State == EntityState.Added).Select(a => a.Entity).Cast<T>().ToList();
 
             var modified =
                 entries.Where(a => a.State == EntityState.Modified).Select(async a => await SelectBothAsync(a)).ToList();
             var removed =
                 entries.Where(a => a.State == EntityState.Deleted).Select(async a => await SelectOriginalAsync(a)).ToList();
-            
+
             var tasks = new List<Task>(removed);
             tasks.AddRange(modified);
 
@@ -308,11 +308,11 @@ namespace BLM.EF6
                     });
                 }
             }
-            
+
             _dbcontext.SaveChanges();
 
-            added.ForEach(async a => await Listen.CreatedAsync(a.Entity, contextInfo));
-            modified.ForEach(async a =>  await Listen.ModifiedAsync((await a).OriginalValues, (await a).CurrentValues, contextInfo));
+            added.ForEach(async a => await Listen.CreatedAsync(a, contextInfo));
+            modified.ForEach(async a => await Listen.ModifiedAsync((await a).OriginalValues, (await a).CurrentValues, contextInfo));
             removed.ForEach(async a => await Listen.RemovedAsync((await a), contextInfo));
         }
 

--- a/BLM.EF6/EfRepository.cs
+++ b/BLM.EF6/EfRepository.cs
@@ -273,15 +273,15 @@ namespace BLM.EF6
                 }
             }
 
-            var removed =
-                entries.Where(a => a.State == EntityState.Deleted).Select(async a => await SelectOriginalAsync(a)).ToList();
-            var added =
-                entries.Where(a => a.State == EntityState.Added).Select(async a => await SelectCurrentAsync(a)).ToList();
+            // Added should be updated after saving changes for get the ID of the newly created entity
+            var added = entries.Where(a => a.State == EntityState.Added).ToList();
+
             var modified =
                 entries.Where(a => a.State == EntityState.Modified).Select(async a => await SelectBothAsync(a)).ToList();
-
+            var removed =
+                entries.Where(a => a.State == EntityState.Deleted).Select(async a => await SelectOriginalAsync(a)).ToList();
+            
             var tasks = new List<Task>(removed);
-            tasks.AddRange(added);
             tasks.AddRange(modified);
 
             await Task.WhenAll(tasks.ToArray());
@@ -311,7 +311,7 @@ namespace BLM.EF6
             
             _dbcontext.SaveChanges();
 
-            added.ForEach(async a => await Listen.CreatedAsync((await a), contextInfo));
+            added.ForEach(async a => await Listen.CreatedAsync(a.Entity, contextInfo));
             modified.ForEach(async a =>  await Listen.ModifiedAsync((await a).OriginalValues, (await a).CurrentValues, contextInfo));
             removed.ForEach(async a => await Listen.RemovedAsync((await a), contextInfo));
         }

--- a/BLM/Loader.cs
+++ b/BLM/Loader.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using BLM.Interfaces.Authorize;
+using BLM.Interfaces.Interpret;
 
 namespace BLM
 {
@@ -85,15 +86,18 @@ namespace BLM
 
                 var entityType = typeof(T);
                 var typesForEntity = GetAllEntriesFor(entityType.GetGenericArguments()[0]);
-                var typesForBlmEntry = typesForEntity.Where(t => 
+                var typesForBlmEntry = typesForEntity.Where(t =>
                     (t.GetInterfaces().Any(intr => intr.IsGenericType && entityType.GetGenericTypeDefinition().IsAssignableFrom(intr.GetGenericTypeDefinition())))
-                    || (   t.BaseType != null 
-                        && t.BaseType.IsAssignableFrom(typeof(IAuthorizeCollection)) 
+                    || (t.BaseType != null
+                        && (t.BaseType.IsAssignableFrom(typeof(IAuthorizeCollection))
+                            || t.BaseType.IsAssignableFrom(typeof(IInterpretBeforeCreate))
+                            || t.BaseType.IsAssignableFrom(typeof(IInterpretBeforeModify))
+                        )
                         && t.BaseType.GetInterfaces().Any(intr => intr.IsGenericType && entityType.GetGenericTypeDefinition().IsAssignableFrom(intr.GetGenericTypeDefinition()))
                     )
                 );
 
-                entries = typesForBlmEntry.Select(type => (IBlmEntry) typeof(Loader).GetMethod("GetInstance").MakeGenericMethod(type).Invoke(null, null)).ToList();
+                entries = typesForBlmEntry.Select(type => (IBlmEntry)typeof(Loader).GetMethod("GetInstance").MakeGenericMethod(type).Invoke(null, null)).ToList();
 
                 EntriesByTypeCache.Add(key, entries);
 


### PR DESCRIPTION
Added list should be updated after saving changes to the database, for get the primary key of the newly created entity