### PR TITLE
BUGFIX: Use lock while searching in the assemblies

### DIFF
--- a/BLM.EF6.Tests/BLM.EF6.Tests.csproj
+++ b/BLM.EF6.Tests/BLM.EF6.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -51,12 +51,10 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.0.5-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.0.5-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="NMemory, Version=1.0.0.0, Culture=neutral, PublicKeyToken=6a46696d54971e6d, processorArchitecture=MSIL">
       <HintPath>..\packages\NMemory.1.1.2\lib\net45\NMemory.dll</HintPath>
@@ -103,6 +101,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props'))" />
   </Target>
 </Project>

--- a/BLM.EF6.Tests/packages.config
+++ b/BLM.EF6.Tests/packages.config
@@ -2,8 +2,8 @@
 <packages>
   <package id="Effort.EF6" version="1.3.0" targetFramework="net452" />
   <package id="EntityFramework" version="6.1.3" targetFramework="net452" />
-  <package id="MSTest.TestAdapter" version="1.1.4-preview" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.0.5-preview" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.1.6-preview" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.0.7-preview" targetFramework="net452" />
   <package id="NMemory" version="1.1.2" targetFramework="net452" />
   <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
 </packages>

--- a/BLM.Tests/BLM.Tests.csproj
+++ b/BLM.Tests/BLM.Tests.csproj
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props')" />
+  <Import Project="..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props" Condition="Exists('..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -39,12 +39,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.0.5-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions, Version=14.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\MSTest.TestFramework.1.0.5-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\MSTest.TestFramework.1.0.7-preview\lib\net45\Microsoft.VisualStudio.TestPlatform.TestFramework.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -80,6 +78,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.4-preview\build\net45\MSTest.TestAdapter.props'))" />
+    <Error Condition="!Exists('..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\MSTest.TestAdapter.1.1.6-preview\build\net45\MSTest.TestAdapter.props'))" />
   </Target>
 </Project>

--- a/BLM.Tests/packages.config
+++ b/BLM.Tests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="MSTest.TestAdapter" version="1.1.4-preview" targetFramework="net452" />
-  <package id="MSTest.TestFramework" version="1.0.5-preview" targetFramework="net452" />
+  <package id="MSTest.TestAdapter" version="1.1.6-preview" targetFramework="net452" />
+  <package id="MSTest.TestFramework" version="1.0.7-preview" targetFramework="net452" />
   <package id="System.Runtime.Caching.Generic" version="1.0.5.0" targetFramework="net452" />
 </packages>

--- a/BLM/Loader.cs
+++ b/BLM/Loader.cs
@@ -34,18 +34,23 @@ namespace BLM
             }
         }
 
+        private static object _loadingTypes = new object();
+
         static void LoadTypes()
         {
-            var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
-            _loadedTypes = new List<Type>();
-            foreach (var assembly in assemblies)
+            lock (_loadingTypes)
             {
-                _loadedTypes.AddRange(
-                    assembly.GetTypes().Where(a =>
-                        a.GetInterfaces().Contains(typeof(IBlmEntry))
-                        && a.IsClass
-                        && !a.IsAbstract
-                        ));
+                var assemblies = AppDomain.CurrentDomain.GetAssemblies().ToList();
+                _loadedTypes = new List<Type>();
+                foreach (var assembly in assemblies)
+                {
+                    _loadedTypes.AddRange(
+                        assembly.GetTypes().Where(a =>
+                            a.GetInterfaces().Contains(typeof(IBlmEntry))
+                            && a.IsClass
+                            && !a.IsAbstract
+                            ));
+                }
             }
         }
 


### PR DESCRIPTION
+ MSTest.TestAdapter updated for live unit testing
 + 	Use lock while searching in the assemblies